### PR TITLE
performance can now also be displayed relatively

### DIFF
--- a/MMM-AVStock.js
+++ b/MMM-AVStock.js
@@ -47,6 +47,7 @@ Module.register("MMM-AVStock", {
         purchasePrice: [0,0,0],
         showPurchasePrices: false,
         showPerformance2Purchase: false,
+        showPerformanceAbsolute: false,
         debug: false,
     },
     
@@ -444,15 +445,18 @@ Module.register("MMM-AVStock", {
         tr.className = "animated stock_item stock_tr " + ud;
         
         /* spitzlbergerj - Extension ticker with line with own purchase price and the display for profit and loss */
-        var ppd = (stock.quote.profit) ? "profit" : "loss";
-        if (this.config.showPurchasePrices) {
-            var purchasePriceTag = document.getElementById("purchasePrice_" + hash);
-            purchasePriceTag.className = "purchasePrice " + ppd;
-            if (this.config.showPerformance2Purchase) {
-                var purchaseChangeTag = document.getElementById("purchaseChange_" + hash);
-                purchaseChangeTag.innerHTML = stock.quote.perf2P;
-                purchaseChangeTag.className = "purchaseChange " + ppd;
-            }
+        var purchasePriceTag = document.getElementById("purchasePrice_" + hash);
+        if (this.config.showPerformance2Purchase) {
+            var purchaseChangeTag = document.getElementById("purchaseChange_" + hash);
+        }
+        var floatStockPrice = parseFloat(stock.quote.price);
+        var floatPurchacePrise = parseFloat(purchasePriceTag.innerHTML);
+        var performace2Purchase = (floatStockPrice / floatPurchacePrise * 100) - ((this.config.showPerformanceAbsolute) ? 0 : 100);
+        var ppd = (floatStockPrice > floatPurchacePrise) ? "profit" : "loss";
+        purchasePriceTag.className = "purchasePrice " + ppd;
+        if (this.config.showPerformance2Purchase) {
+            purchaseChangeTag.innerHTML = this.formatNumber(performace2Purchase, 0) + "%";
+            purchaseChangeTag.className = "purchaseChange " + ppd;
         }
         /* spitzlbergerj - end */
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ MagicMirror module for displaying stock price using the Alphavantage API.
 
 ## UPDATES ##
 
+** spitzlbergerj, 20200913 **
+- performance can now also be displayed relatively by using the option showPerformanceAbsolute
 
 ** 2.2.0 **
 - (by spitzlbergerj) within the ticker mode, a line with the own purchase price and the display for profit and loss is added. The performance compared to the own purchase price can be displayed too.
@@ -133,6 +135,7 @@ I am working on an alternative API.
         showVolume: false,
         showPurchasePrices: true,
         showPerformance2Purchase: true,
+        showPerformanceAbsolute: true,
     }
 },
 ```
@@ -152,6 +155,7 @@ I am working on an alternative API.
 | `purchasePrice` | array | [123.45, 123.45, 123.45] | Array of own purchase prices |
 | `showPurchasePrices` | boolean | false | Whether to show the own purchase prices. |
 | `showPerformance2Purchase` | boolean | false | Whether to show the total performace compared to the own purchase prices. |
+| `showPerformanceAbsolute` | boolean | false | Whether to show the total performace as absolute or relative value. |
 | `locale` | string | config.locale | Locale to convert numbers to the respective number format. |
 | `tickerDuration` | integer | 20 | Determines ticker speed |
 | `chartDays` | integer | 90 | Number of days to show in the chart. (Max 90 days!) |


### PR DESCRIPTION
Option showPerformanceAbsolute introduced. If this is true, a 20% increase in value is displayed as 120% (purchase price 100 EUR, current price 120 EUR). By default this increase is now displayed as 20%.