### PR TITLE
Fix compatibility with yahoo-finance2 v3

### DIFF
--- a/MMM-AVStock.js
+++ b/MMM-AVStock.js
@@ -426,6 +426,7 @@ Module.register("MMM-AVStock", {
             this.stocks[symbol]["quotes"] = this.formatQuotes(payload.quotes);
             this.stocks[symbol]["hist"] = (payload.historical && payload.historical !== "") ? this.formatOHLC(payload.historical) : [];
             this.updateData(this.config.mode);
+            if (document.getElementById("AVSTOCK_TAGLINE")) document.getElementById("AVSTOCK_TAGLINE").innerHTML = "Last quote: " + moment(this.updateTime).format("MM-DD HH:mm");
             if (!this.loaded) { 
                 this.loaded = true;
                 this.log(this.name + " fully loaded...")

--- a/MMM-AVStock.js
+++ b/MMM-AVStock.js
@@ -424,7 +424,7 @@ Module.register("MMM-AVStock", {
             this.log(payload);
             var symbol = payload.quotes.price.symbol;
             this.stocks[symbol]["quotes"] = this.formatQuotes(payload.quotes);
-            this.stocks[symbol]["hist"] = this.formatOHLC(payload.historical);
+            this.stocks[symbol]["hist"] = (payload.historical && payload.historical !== "") ? this.formatOHLC(payload.historical) : [];
             this.updateData(this.config.mode);
             if (!this.loaded) { 
                 this.loaded = true;

--- a/node_helper.js
+++ b/node_helper.js
@@ -1,4 +1,5 @@
-const yfinance2 = require('yahoo-finance2').default;
+const YahooFinance = require('yahoo-finance2').default;
+const yfinance2 = new YahooFinance();
 const moment = require('moment');
 
 var NodeHelper = require("node_helper")


### PR DESCRIPTION
- Update node_helper.js to instantiate YahooFinance class (required for v3)
- Add error handling in MMM-AVStock.js for empty historical data
- Prevents crash when historical data is unavailable

Fixes issues where module would not display stock quotes after upgrading to yahoo-finance2 v3.x